### PR TITLE
Model ingestion as a pipeline

### DIFF
--- a/katniss-ingestor/Cargo.toml
+++ b/katniss-ingestor/Cargo.toml
@@ -12,4 +12,13 @@ thiserror = "1.0.39"
 arrow-schema = "33.0.0"
 itertools = "0.10.5"
 lance = { git = "https://github.com/eto-ai/lance.git", branch = "main" }
-tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.0", default-features = false, features = [
+    "macros",
+    "rt",
+    "rt-multi-thread",
+] }
+
+
+[dev-dependencies]
+anyhow = "1.0.69"
+katniss-test = { path = "../katniss-test" }

--- a/katniss-ingestor/Cargo.toml
+++ b/katniss-ingestor/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 parquet = "33.0.0"
+chrono = "0.4.23"
 katniss-pb2arrow = { path = "../katniss-pb2arrow" }
 thiserror = "1.0.39"
 arrow-schema = "33.0.0"
@@ -22,3 +23,4 @@ tokio = { version = "1.0", default-features = false, features = [
 [dev-dependencies]
 anyhow = "1.0.69"
 katniss-test = { path = "../katniss-test" }
+tempfile = "3.4.0"

--- a/katniss-ingestor/src/arrow.rs
+++ b/katniss-ingestor/src/arrow.rs
@@ -1,23 +1,25 @@
 use katniss_pb2arrow::{
     exports::{DynamicMessage, RecordBatch},
-    ArrowBatchProps, RecordBatchConverter,
+    ArrowBatchProps, RecordConverter,
 };
 
 pub use crate::Result;
-pub struct ProtobufIngestor {
+
+/// Ingests individual Protobuf Messages, and returns a batch if batch_size threshhold is crossed.
+pub struct ProtobufBatchIngestor {
     batch_size: usize,
-    converter: RecordBatchConverter,
+    converter: RecordConverter,
 }
 
-impl ProtobufIngestor {
-    pub fn new(props: ArrowBatchProps) -> Result<Self> {
-        let batch_size = props.arrow_record_batch_size;
+impl ProtobufBatchIngestor {
+    pub fn new(props: &ArrowBatchProps) -> Result<Self> {
+        let batch_size = props.records_per_arrow_batch;
 
-        let converter = RecordBatchConverter::try_new(&props)?;
+        let converter = RecordConverter::try_new(&props)?;
 
         Ok(Self {
-            batch_size,
-            converter,
+            batch_size: props.records_per_arrow_batch,
+            converter: RecordConverter::try_from(props)?,
         })
     }
 
@@ -26,14 +28,23 @@ impl ProtobufIngestor {
         self.converter.append_message(&msg)?;
 
         if self.converter.len() >= self.batch_size {
-            Ok(Some(self.converter.records()?))
+            Ok(Some(self.converter.records()))
         } else {
             Ok(None)
         }
     }
 
-    pub fn finish(mut self) -> Result<RecordBatch> {
-        let records = self.converter.records()?;
+    pub fn finish(&mut self) -> Result<RecordBatch> {
+        let records = self.converter.records();
         Ok(records)
+    }
+
+    pub fn len(&self) -> usize {
+        self.converter.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }

--- a/katniss-ingestor/src/arrow.rs
+++ b/katniss-ingestor/src/arrow.rs
@@ -12,11 +12,7 @@ pub struct ProtobufBatchIngestor {
 }
 
 impl ProtobufBatchIngestor {
-    pub fn new(props: &ArrowBatchProps) -> Result<Self> {
-        let batch_size = props.records_per_arrow_batch;
-
-        let converter = RecordConverter::try_new(&props)?;
-
+    pub fn try_new(props: &ArrowBatchProps) -> Result<Self> {
         Ok(Self {
             batch_size: props.records_per_arrow_batch,
             converter: RecordConverter::try_from(props)?,

--- a/katniss-ingestor/src/errors.rs
+++ b/katniss-ingestor/src/errors.rs
@@ -1,7 +1,13 @@
-use std::time::SystemTimeError;
+use std::{
+    fmt::Debug,
+    sync::mpsc::{RecvError, SendError},
+    time::SystemTimeError,
+};
 
 use katniss_pb2arrow::KatnissArrowError;
 use thiserror::Error;
+
+use crate::pipeline::{TemporalBuffer, TemporalBytes};
 
 #[derive(Error, Debug)]
 pub enum KatinssIngestorError {
@@ -17,6 +23,12 @@ pub enum KatinssIngestorError {
     #[error("Timelord Error: {0}")]
     TimeyWimeyStuff(#[from] SystemTimeError),
 
-    #[error("Failed to lock data")]
-    OtherSharedBufferReferenceHeld,
+    #[error("Pipeline Clog: {0}")]
+    BufferRecv(#[from] RecvError),
+
+    #[error("Temporal Pipeline Clog: {0}")]
+    TemporalBufferSend(#[from] SendError<TemporalBuffer>),
+
+    #[error("Parquet Pipeline Clog: {0}")]
+    ParquetBufferSend(#[from] SendError<TemporalBytes>),
 }

--- a/katniss-ingestor/src/ingestors/lance_fs_ingestor.rs
+++ b/katniss-ingestor/src/ingestors/lance_fs_ingestor.rs
@@ -9,13 +9,13 @@ use katniss_pb2arrow::exports::prost_reflect::{DescriptorPool, DynamicMessage, M
 use katniss_pb2arrow::exports::{RecordBatch, RecordBatchReader};
 use tokio::runtime::Runtime;
 
-use crate::{arrow::ProtobufIngestor, Result};
+use crate::{arrow::ProtobufBatchIngestor, Result};
 
 use super::BatchIngestor;
 
 pub struct LanceFsIngestor {
     descriptor: MessageDescriptor,
-    ingestor: ProtobufIngestor,
+    ingestor: ProtobufBatchIngestor,
     rt: Arc<Runtime>,
     filename: String,
     params: WriteParams,
@@ -30,9 +30,9 @@ pub struct LanceFsIngestorProps<'a, P: AsRef<Path>> {
 }
 
 impl LanceFsIngestor {
-    pub fn new<P: AsRef<Path>>(props: ArrowBatchProps, filename: P) -> Result<Self> {
+    pub fn new<P: AsRef<Path>>(props: &ArrowBatchProps, filename: P) -> Result<Self> {
         let descriptor = props.descriptor.clone();
-        let ingestor = ProtobufIngestor::new(props)?;
+        let ingestor = ProtobufBatchIngestor::new(props)?;
 
         let filename = filename.as_ref().to_str().unwrap().to_string();
 

--- a/katniss-ingestor/src/ingestors/lance_fs_ingestor.rs
+++ b/katniss-ingestor/src/ingestors/lance_fs_ingestor.rs
@@ -32,7 +32,7 @@ pub struct LanceFsIngestorProps<'a, P: AsRef<Path>> {
 impl LanceFsIngestor {
     pub fn new<P: AsRef<Path>>(props: &ArrowBatchProps, filename: P) -> Result<Self> {
         let descriptor = props.descriptor.clone();
-        let ingestor = ProtobufBatchIngestor::new(props)?;
+        let ingestor = ProtobufBatchIngestor::try_new(props)?;
 
         let filename = filename.as_ref().to_str().unwrap().to_string();
 

--- a/katniss-ingestor/src/ingestors/parquet_buffered.rs
+++ b/katniss-ingestor/src/ingestors/parquet_buffered.rs
@@ -32,7 +32,7 @@ impl BufferedParquetIngestor {
             props.arrow_batches_per_parquet,
         )?;
 
-        let ingestor = ProtobufBatchIngestor::new(arrow_props)?;
+        let ingestor = ProtobufBatchIngestor::try_new(arrow_props)?;
 
         Ok(Self { writer, ingestor })
     }

--- a/katniss-ingestor/src/ingestors/parquet_buffered.rs
+++ b/katniss-ingestor/src/ingestors/parquet_buffered.rs
@@ -5,16 +5,16 @@ use katniss_pb2arrow::{
     ArrowBatchProps,
 };
 
-use crate::{arrow::ProtobufIngestor, parquet::MultiBatchWriter, Result};
+use crate::{arrow::ProtobufBatchIngestor, parquet::MultiBatchWriter, Result};
 
 /// Buffered ingestor consumes individual packets from an external source
-/// e.g. (a socket)and ultimately commits them to a parquet file. Currently
+/// e.g. (a socket) and ultimately commits them to a parquet file. Currently
 /// this works by waiting for a fixed number of arrow batches to have been
 /// ingested, ideally, this would be temporally based. File system access
 /// is strictly controlled to allow use at edge on devices with flash drives.
 pub struct BufferedParquetIngestor {
     writer: MultiBatchWriter,
-    ingestor: ProtobufIngestor,
+    ingestor: ProtobufBatchIngestor,
 }
 
 pub struct BufferedIngestorProps<'a> {
@@ -25,13 +25,14 @@ pub struct BufferedIngestorProps<'a> {
 }
 
 impl BufferedParquetIngestor {
-    pub fn new(arrow_props: ArrowBatchProps, props: BufferedIngestorProps) -> Result<Self> {
+    pub fn new(arrow_props: &ArrowBatchProps, props: BufferedIngestorProps) -> Result<Self> {
         let writer = MultiBatchWriter::new(
             "data/parquet".into(),
             arrow_props.schema.clone(),
             props.arrow_batches_per_parquet,
         )?;
-        let ingestor = ProtobufIngestor::new(arrow_props)?;
+
+        let ingestor = ProtobufBatchIngestor::new(arrow_props)?;
 
         Ok(Self { writer, ingestor })
     }

--- a/katniss-ingestor/src/ingestors/parquet_fs.rs
+++ b/katniss-ingestor/src/ingestors/parquet_fs.rs
@@ -24,7 +24,7 @@ impl ParquetFileIngestor {
 
         let writer = ArrowWriter::try_new(file, arrow_props.schema.clone(), Some(writer_props))?;
 
-        let ingestor = ProtobufBatchIngestor::new(arrow_props)?;
+        let ingestor = ProtobufBatchIngestor::try_new(arrow_props)?;
 
         Ok(Self { writer, ingestor })
     }

--- a/katniss-ingestor/src/ingestors/parquet_fs.rs
+++ b/katniss-ingestor/src/ingestors/parquet_fs.rs
@@ -4,28 +4,27 @@ use std::{fs::File, path::Path};
 use katniss_pb2arrow::{exports::prost_reflect::DynamicMessage, ArrowBatchProps};
 use parquet::{arrow::ArrowWriter, file::properties::WriterProperties};
 
-use crate::{arrow::ProtobufIngestor, Result};
+use crate::{arrow::ProtobufBatchIngestor, Result};
 
 use super::BatchIngestor;
 
 /// File Ingestor ingests arrow batches to parquet file, allowing all disk access
 pub struct ParquetFileIngestor {
     writer: ArrowWriter<File>,
-    ingestor: ProtobufIngestor,
+    ingestor: ProtobufBatchIngestor,
 }
 
 impl ParquetFileIngestor {
-    pub fn new<P: AsRef<Path>>(arrow_props: ArrowBatchProps, filename: P) -> Result<Self> {
+    pub fn new<P: AsRef<Path>>(arrow_props: &ArrowBatchProps, filename: P) -> Result<Self> {
         let file = File::create(filename)?;
-
-        let schema = arrow_props.schema.clone();
-        let ingestor = ProtobufIngestor::new(arrow_props)?;
 
         let writer_props = WriterProperties::builder()
             .set_max_row_group_size(1024 * 10)
             .build();
 
-        let writer = ArrowWriter::try_new(file, schema, Some(writer_props))?;
+        let writer = ArrowWriter::try_new(file, arrow_props.schema.clone(), Some(writer_props))?;
+
+        let ingestor = ProtobufBatchIngestor::new(arrow_props)?;
 
         Ok(Self { writer, ingestor })
     }

--- a/katniss-ingestor/src/ingestors/proto_repeated.rs
+++ b/katniss-ingestor/src/ingestors/proto_repeated.rs
@@ -29,10 +29,10 @@ pub enum Serialization<P: AsRef<Path>> {
 impl<B: Buf> RepeatedProtoIngestor<B> {
     pub fn new<P: AsRef<Path>>(
         bytes: B,
-        arrow_props: ArrowBatchProps,
+        arrow_props: &ArrowBatchProps,
         serialization: Serialization<P>,
     ) -> Result<Self> {
-        let arrow_batch_size = arrow_props.arrow_record_batch_size;
+        let arrow_batch_size = arrow_props.records_per_arrow_batch;
         let descriptor = arrow_props.descriptor.clone();
         let packet_ingestor: Box<dyn BatchIngestor> = match serialization {
             Serialization::Parquet { filename } => {

--- a/katniss-ingestor/src/lib.rs
+++ b/katniss-ingestor/src/lib.rs
@@ -2,6 +2,6 @@ pub mod arrow;
 pub mod errors;
 pub mod ingestors;
 pub mod parquet;
-pub mod temporal;
+pub mod pipeline;
 
 pub type Result<T> = core::result::Result<T, errors::KatinssIngestorError>;

--- a/katniss-ingestor/src/lib.rs
+++ b/katniss-ingestor/src/lib.rs
@@ -2,5 +2,6 @@ pub mod arrow;
 pub mod errors;
 pub mod ingestors;
 pub mod parquet;
+pub mod temporal;
 
 pub type Result<T> = core::result::Result<T, errors::KatinssIngestorError>;

--- a/katniss-ingestor/src/pipeline.rs
+++ b/katniss-ingestor/src/pipeline.rs
@@ -1,0 +1,9 @@
+mod buffers;
+mod file_sink;
+mod parquet_converter;
+mod temporal_rotator;
+
+pub use buffers::{TemporalBuffer, TemporalBytes};
+pub use file_sink::FileSink;
+pub use parquet_converter::ParquetConsumer;
+pub use temporal_rotator::TemporalRotator;

--- a/katniss-ingestor/src/pipeline/buffers.rs
+++ b/katniss-ingestor/src/pipeline/buffers.rs
@@ -1,0 +1,32 @@
+use chrono::{DateTime, Duration, Utc};
+
+use katniss_pb2arrow::exports::RecordBatch;
+
+pub struct TemporalBuffer {
+    pub begin_at: DateTime<Utc>,
+    pub end_at: DateTime<Utc>,
+    pub batches: Vec<RecordBatch>,
+}
+
+impl TemporalBuffer {
+    pub fn new(now: DateTime<Utc>) -> Self {
+        let end_at = now + Duration::seconds(60);
+        Self {
+            begin_at: now,
+            end_at,
+            batches: Vec::new(),
+        }
+    }
+}
+
+pub struct TemporalBytes {
+    pub begin_at: DateTime<Utc>,
+    pub end_at: DateTime<Utc>,
+    pub bytes: Vec<u8>,
+}
+
+impl TemporalBytes {
+    pub fn begin_timestamp(&self) -> String {
+        self.begin_at.format("%Y-%m-%d-%H%M%S_utc").to_string()
+    }
+}

--- a/katniss-ingestor/src/pipeline/file_sink.rs
+++ b/katniss-ingestor/src/pipeline/file_sink.rs
@@ -1,0 +1,90 @@
+use std::{fs, path::PathBuf, sync::mpsc::Receiver};
+
+use crate::{pipeline::TemporalBytes, Result};
+
+pub struct FileSink {
+    rx: Receiver<TemporalBytes>,
+    directory: PathBuf,
+}
+
+impl FileSink {
+    pub fn new<P: Into<PathBuf>>(rx: Receiver<TemporalBytes>, directory: P) -> Self {
+        Self {
+            rx,
+            directory: directory.into(),
+        }
+    }
+
+    pub fn sink_next(&self) -> Result<()> {
+        let buf = self.rx.recv()?;
+        fs::write(self.filename_for(&buf), buf.bytes)?;
+        Ok(())
+    }
+
+    /// Returns pretty formatted start time in directory
+    fn filename_for(&self, data: &TemporalBytes) -> PathBuf {
+        self.directory
+            .join(data.begin_timestamp())
+            .with_extension("parquet")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc::channel;
+
+    use chrono::{Duration, TimeZone, Utc};
+
+    use crate::pipeline::TemporalBytes;
+    use tempfile::tempdir;
+
+    use super::FileSink;
+
+    #[test]
+    fn test_name() -> anyhow::Result<()> {
+        let (tx, rx) = channel();
+        let temp_dir = tempdir()?;
+
+        let sink = FileSink::new(rx, temp_dir.path());
+        let data = TemporalBytes {
+            begin_at: Utc::now(),
+            end_at: Utc::now(),
+            bytes: b"HEY GIRL".to_vec(),
+        };
+
+        let filename = sink.filename_for(&data);
+
+        tx.send(data)?;
+
+        sink.sink_next()?;
+        assert_eq!(b"HEY GIRL", &std::fs::read(filename)?[..]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn filenames_are_pretty() -> anyhow::Result<()> {
+        let (_tx, rx) = channel();
+
+        let sink = FileSink::new(rx, "some_directory");
+        let now = Utc.timestamp_nanos(1678307941000000000);
+
+        let begin_at = now;
+        let end_at = now + Duration::seconds(60);
+
+        let data = TemporalBytes {
+            begin_at,
+            end_at,
+            bytes: Default::default(),
+        };
+
+        let filename = sink.filename_for(&data);
+
+        assert_eq!(
+            "some_directory/2023-03-08-203901_utc.parquet",
+            filename.as_os_str()
+        );
+
+        Ok(())
+    }
+}

--- a/katniss-ingestor/src/pipeline/parquet_converter.rs
+++ b/katniss-ingestor/src/pipeline/parquet_converter.rs
@@ -1,0 +1,96 @@
+// dynamic messages => temporal buffers (mutiple recordBatches) => (Timestamp, parquet/bytes ) | Timestamp LanceBytes => (filesysem/s3/gcp)
+
+use std::sync::mpsc::{channel, Receiver, Sender};
+
+use arrow_schema::SchemaRef;
+use parquet::{arrow::ArrowWriter, file::properties::WriterProperties};
+
+use super::{TemporalBuffer, TemporalBytes};
+use crate::Result;
+
+pub struct ParquetConsumer {
+    rx: Receiver<TemporalBuffer>,
+    tx: Sender<TemporalBytes>,
+    schema: SchemaRef,
+    parquet_props: WriterProperties,
+}
+
+impl ParquetConsumer {
+    pub fn new(rx: Receiver<TemporalBuffer>, schema: SchemaRef) -> (Self, Receiver<TemporalBytes>) {
+        let (tx, rx_bytes) = channel();
+
+        let parquet_props = WriterProperties::builder()
+            .set_max_row_group_size(1024 * 10) //Our data shape goes quadratic with larger group sizes
+            .build();
+
+        let consumer = Self {
+            rx,
+            tx,
+            schema,
+            parquet_props,
+        };
+
+        (consumer, rx_bytes)
+    }
+
+    pub fn with_parquet_writer_props(mut self, props: WriterProperties) -> Self {
+        self.parquet_props = props;
+        self
+    }
+
+    pub fn process_next_buffer(&mut self) -> Result<()> {
+        let buf = self.rx.recv()?;
+        let mut writer = ArrowWriter::try_new(
+            Vec::<u8>::new(), // this could probably be a with_capacity with *some* number
+            self.schema.clone(),
+            Some(self.parquet_props.clone()),
+        )?;
+
+        for batch in buf.batches {
+            writer.write(&batch)?;
+        }
+
+        let bytes = writer.into_inner()?;
+
+        self.tx.send(TemporalBytes {
+            begin_at: buf.begin_at,
+            end_at: buf.end_at,
+            bytes,
+        })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use chrono::Utc;
+    use katniss_pb2arrow::exports::prost_reflect::bytes::Bytes;
+    use katniss_test::schema_converter;
+    use parquet::file::{reader::FileReader, serialized_reader::SerializedFileReader};
+
+    use super::*;
+
+    #[test]
+    fn it_consumes_temporal_buffers_into_parquet_bytes() -> anyhow::Result<()> {
+        let (tx_buffer, rx) = channel();
+        let schema = schema_converter()?
+            .get_arrow_schema("eto.pb2arrow.tests.spacecorp.Packet", &[])?
+            .unwrap();
+
+        let (mut consumer, rx_bytes) = ParquetConsumer::new(rx, Arc::new(schema));
+        tx_buffer.send(TemporalBuffer::new(Utc::now()))?;
+        assert!(rx_bytes.try_recv().is_err());
+
+        consumer.process_next_buffer()?;
+
+        let bytes = rx_bytes.try_recv()?;
+
+        let reader = SerializedFileReader::new(Bytes::from(bytes.bytes))?;
+        //TODO– give initial buffer a batch to see a row group happen
+        assert_eq!(0, reader.metadata().num_row_groups());
+        Ok(())
+    }
+}

--- a/katniss-ingestor/src/temporal.rs
+++ b/katniss-ingestor/src/temporal.rs
@@ -1,0 +1,125 @@
+use std::time::{Duration, SystemTime};
+
+use katniss_pb2arrow::{
+    exports::{DynamicMessage, RecordBatch},
+    ArrowBatchProps,
+};
+
+use crate::{arrow::ProtobufBatchIngestor, Result};
+
+pub struct TemporalBuffer {
+    pub begin_at: SystemTime,
+    pub end_at: SystemTime,
+    pub batches: Vec<RecordBatch>,
+}
+
+impl TemporalBuffer {
+    fn new(now: SystemTime) -> Self {
+        let end_at = now + Duration::from_secs(60);
+        Self {
+            begin_at: now,
+            end_at,
+            batches: Vec::new(),
+        }
+    }
+}
+
+/// Rotates the in-memory buffer it is written to per a timescale,
+/// Currently hardcoded to rotate every 60 seconds
+/// we should probably do some more timelord stuff to have buffers line up with minutes
+/// we could also make the duration configurable but YOLO
+pub struct TemporalRotator {
+    pub converter: ProtobufBatchIngestor,
+    pub current: TemporalBuffer,
+    pub past: Vec<TemporalBuffer>,
+}
+
+impl TemporalRotator {
+    pub fn new(props: &ArrowBatchProps, now: SystemTime) -> Result<Self> {
+        Ok(Self {
+            converter: ProtobufBatchIngestor::new(props)?,
+            current: TemporalBuffer::new(now),
+            past: Default::default(),
+        })
+    }
+
+    pub fn ingest(&mut self, msg: DynamicMessage, now: SystemTime) -> Result<()> {
+        if now > self.current.end_at {
+            let batch = self.converter.finish()?;
+            self.current.batches.push(batch);
+
+            let old = std::mem::replace(&mut self.current, TemporalBuffer::new(now));
+            self.past.push(old);
+        }
+
+        if let Some(batch) = self.converter.ingest_message(msg)? {
+            self.current.batches.push(batch)
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::time::{Duration, SystemTime};
+
+    use katniss_pb2arrow::ArrowBatchProps;
+
+    use katniss_test::{descriptor_pool, protos::spacecorp::Packet, test_util::to_dynamic};
+
+    const PACKET: &str = "eto.pb2arrow.tests.spacecorp.Packet";
+
+    #[test]
+    fn it_rotates_on_a_time_period() -> anyhow::Result<()> {
+        let start = SystemTime::now();
+        let mut rotator = TemporalRotator::new(
+            &ArrowBatchProps::new(descriptor_pool()?, PACKET.to_owned())?
+                .with_records_per_arrow_batch(2),
+            start,
+        )?;
+
+        rotator.ingest(
+            to_dynamic(&Packet::default(), PACKET)?,
+            start + Duration::from_secs(1),
+        )?;
+        rotator.ingest(
+            to_dynamic(&Packet::default(), PACKET)?,
+            start + Duration::from_secs(2),
+        )?;
+        rotator.ingest(
+            to_dynamic(&Packet::default(), PACKET)?,
+            start + Duration::from_secs(5),
+        )?;
+        rotator.ingest(
+            to_dynamic(&Packet::default(), PACKET)?,
+            start + Duration::from_secs(10),
+        )?;
+        rotator.ingest(
+            to_dynamic(&Packet::default(), PACKET)?,
+            start + Duration::from_secs(20),
+        )?;
+
+        assert_eq!(2, rotator.current.batches.len()); //two completed batches of 2
+        assert_eq!(1, rotator.converter.len()); //one unprocessed record
+
+        // ingesting a packet more than 60 seconds in future rotates buffers
+        rotator.ingest(
+            to_dynamic(&Packet::default(), PACKET)?,
+            start + Duration::from_secs(61),
+        )?;
+        assert_eq!(
+            vec![2, 2, 1],
+            rotator.past[0]
+                .batches
+                .iter()
+                .map(|b| b.num_rows())
+                .collect::<Vec<_>>()
+        ); // two completed batches of 2
+        assert_eq!(0, rotator.current.batches.len()); // Fresh temporal buffer has no batches
+        assert_eq!(1, rotator.converter.len()); // one unprocessed record
+
+        Ok(())
+    }
+}

--- a/katniss-pb2arrow/src/record_conversion.rs
+++ b/katniss-pb2arrow/src/record_conversion.rs
@@ -1,34 +1,31 @@
 use arrow_array::builder::*;
 use arrow_array::RecordBatch;
-use arrow_schema::{ArrowError, SchemaRef};
+use arrow_schema::SchemaRef;
 use prost_reflect::DynamicMessage;
 
+use self::builder_appending::append_all_fields;
+use self::builder_creation::BuilderFactory;
 use crate::ArrowBatchProps;
 use crate::KatnissArrowError;
 use crate::Result;
 
-use self::builder_appending::append_all_fields;
-use self::builder_creation::BuilderFactory;
-
 mod builder_appending;
 mod builder_creation;
 
-/// Parse messages and return RecordBatch
-pub struct RecordBatchConverter {
+/// Converterts records from protobuf to arrow
+/// Holds records in the builder until records() is called draining builder.
+pub struct RecordConverter {
     pub(crate) schema: SchemaRef,
-    #[allow(unused)]
-    batch_size: usize,
     builder: StructBuilder, // fields align with schema
 }
 
-impl RecordBatchConverter {
+impl RecordConverter {
     pub fn try_new(props: &ArrowBatchProps) -> Result<Self> {
-        let batch_size = props.arrow_record_batch_size;
+        let batch_size = props.records_per_arrow_batch;
         let factory = BuilderFactory::new_with_dictionary(props.dictionaries.clone());
         let builder = factory.try_from_fields(props.schema.fields().clone(), batch_size)?;
-        Ok(RecordBatchConverter {
+        Ok(Self {
             schema: props.schema.clone(),
-            batch_size,
             builder,
         })
     }
@@ -38,8 +35,10 @@ impl RecordBatchConverter {
         append_all_fields(self.schema.fields(), &mut self.builder, Some(msg))
     }
 
-    pub fn schema(&self) -> SchemaRef {
-        self.schema.clone()
+    /// Returns record batch and resets the builder
+    pub fn records(&mut self) -> RecordBatch {
+        let struct_array = self.builder.finish();
+        RecordBatch::from(&struct_array)
     }
 
     /// Number of rows in this batch so far
@@ -51,18 +50,11 @@ impl RecordBatchConverter {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
-
-    pub fn records(&mut self) -> Result<RecordBatch> {
-        RecordBatch::try_from(self).map_err(KatnissArrowError::BatchConversionError)
-    }
 }
 
-/// Convert RecordBatch from RecordBatchConverter.
-impl TryFrom<&mut RecordBatchConverter> for RecordBatch {
-    type Error = ArrowError;
-
-    fn try_from(converter: &mut RecordBatchConverter) -> core::result::Result<Self, Self::Error> {
-        let struct_array = converter.builder.finish();
-        Ok(RecordBatch::from(&struct_array))
+impl TryFrom<&ArrowBatchProps> for RecordConverter {
+    type Error = KatnissArrowError;
+    fn try_from(props: &ArrowBatchProps) -> Result<Self> {
+        RecordConverter::try_new(props)
     }
 }

--- a/katniss-pb2arrow/src/schema_conversion.rs
+++ b/katniss-pb2arrow/src/schema_conversion.rs
@@ -9,11 +9,11 @@ use std::path::Path;
 use std::process::Command;
 
 use arrow_schema::DataType::Utf8;
-use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use arrow_schema::{DataType, Field, Schema};
 use prost_reflect::{DescriptorPool, FieldDescriptor, MessageDescriptor};
 use tempfile::NamedTempFile;
 
-use crate::{KatnissArrowError, RecordBatchConverter, Result};
+use crate::{KatnissArrowError, Result};
 
 /// Holds dictionary values for fields. Not threadsafe
 #[derive(Debug, Clone)]

--- a/katniss-test/src/bin/columnify.rs
+++ b/katniss-test/src/bin/columnify.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let ingestor = RepeatedProtoIngestor::new(
         &source_file[..],
-        ArrowBatchProps::new(descriptor_pool()?, "Packet".to_owned(), 1024)?,
+        &ArrowBatchProps::new(descriptor_pool()?, "Packet".to_owned())?,
         cli.serialization(),
     )?;
 

--- a/katniss-test/src/integration_tests.rs
+++ b/katniss-test/src/integration_tests.rs
@@ -1,4 +1,3 @@
 mod proto_repeated_tests;
 mod proto_through_parquet_ingestion_tests;
 mod test_parse_dict_field;
-mod test_util;

--- a/katniss-test/src/integration_tests/proto_repeated_tests.rs
+++ b/katniss-test/src/integration_tests/proto_repeated_tests.rs
@@ -21,10 +21,9 @@ fn test_log_to_lance() -> Result<()> {
 
     let ingestor = RepeatedProtoIngestor::new(
         bytes,
-        ArrowBatchProps::new(
+        &ArrowBatchProps::new(
             descriptor_pool()?,
             "eto.pb2arrow.tests.spacecorp.Packet".to_owned(),
-            1024,
         )?,
         Serialization::Lance {
             filename: "test_out.lance",

--- a/katniss-test/src/integration_tests/proto_through_parquet_ingestion_tests.rs
+++ b/katniss-test/src/integration_tests/proto_through_parquet_ingestion_tests.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 
-use super::*;
 use crate::{
     protos::{
         spacecorp::{packet, ClimateStatus, JumpDriveStatus, Packet},
@@ -10,8 +9,8 @@ use crate::{
         },
     },
     schema_converter,
+    test_util::*,
 };
-use test_util::*;
 
 #[test]
 fn test_nested_unit_message() -> Result<()> {

--- a/katniss-test/src/integration_tests/temporal_ingestor_tests.rs
+++ b/katniss-test/src/integration_tests/temporal_ingestor_tests.rs
@@ -1,0 +1,57 @@
+use std::time::{Duration, SystemTime};
+
+use katniss_ingestor::temporal::TemporalRotator;
+use katniss_pb2arrow::ArrowBatchProps;
+
+use crate::{descriptor_pool, protos::spacecorp::Packet};
+
+use super::test_util::to_dynamic;
+const PACKET: &str = "eto.pb2arrow.tests.spacecorp.Packet";
+
+#[test]
+fn feature() -> anyhow::Result<()> {
+    let start = SystemTime::now();
+    let mut rotator = TemporalRotator::new(
+        &ArrowBatchProps::new(
+            descriptor_pool()?,
+            PACKET.to_owned(),
+            2, //small batch size to test multi-level rotation
+        )?,
+        start,
+    )?;
+
+    rotator.ingest(
+        to_dynamic(&Packet::default(), PACKET)?,
+        start + Duration::from_secs(1),
+    )?;
+    rotator.ingest(
+        to_dynamic(&Packet::default(), PACKET)?,
+        start + Duration::from_secs(2),
+    )?;
+    rotator.ingest(
+        to_dynamic(&Packet::default(), PACKET)?,
+        start + Duration::from_secs(5),
+    )?;
+    rotator.ingest(
+        to_dynamic(&Packet::default(), PACKET)?,
+        start + Duration::from_secs(10),
+    )?;
+    rotator.ingest(
+        to_dynamic(&Packet::default(), PACKET)?,
+        start + Duration::from_secs(20),
+    )?;
+
+    assert_eq!(2, rotator.current.batches.len()); //two completed batches of 2
+    assert_eq!(1, rotator.converter.len()); //one unprocessed record
+
+    // ingesting a packet more than 60 seconds in future rotates buffers
+    rotator.ingest(
+        to_dynamic(&Packet::default(), PACKET)?,
+        start + Duration::from_secs(61),
+    )?;
+    assert_eq!(3, rotator.past[0].batches.len()); // two completed batches of 2
+    assert_eq!(0, rotator.current.batches.len()); // Fresh temporal buffer has no batches
+    assert_eq!(1, rotator.converter.len()); // one unprocessed record
+
+    Ok(())
+}

--- a/katniss-test/src/integration_tests/test_parse_dict_field.rs
+++ b/katniss-test/src/integration_tests/test_parse_dict_field.rs
@@ -11,7 +11,6 @@ use crate::{
     },
     schema_converter,
 };
-use test_util::*;
 
 #[test] #[ignore]
 fn test_parse_dict_field_values() -> Result<()> {

--- a/katniss-test/src/lib.rs
+++ b/katniss-test/src/lib.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use katniss_pb2arrow::SchemaConverter;
 use prost_reflect::DescriptorPool;
 
+pub mod test_util;
 pub mod protos {
     pub const FILE_DESCRIPTOR_BYTES: &[u8] =
         include_bytes!(concat!(env!("OUT_DIR"), "/file_descriptor_set.bin"));


### PR DESCRIPTION
Ingestion starts with TemporalRotator which rotates a buffers for a time period (60s currently)

It moves through a ParquetConverter

Then goes to a FileSink.

I'm trying to set us up for lance converters and Cloud Sinks

Currently uses std::mpsc channels, could hard commit to tokio, but a bunch of the actions block for too long
so we'd have to spawn more tasks and be more careful,
