### PR TITLE
Handle enum values from the schema

### DIFF
--- a/katniss-ingestor/Cargo.toml
+++ b/katniss-ingestor/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-parquet = "34.0.0"
+parquet = "33.0.0"
 katniss-pb2arrow = { path = "../katniss-pb2arrow" }
-thiserror = "1.0.38"
-arrow-schema = "34.0.0"
+thiserror = "1.0.39"
+arrow-schema = "33.0.0"
 itertools = "0.10.5"

--- a/katniss-pb2arrow/Cargo.toml
+++ b/katniss-pb2arrow/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow-array = "34.0.0"
-arrow-schema = "34.0.0"
+arrow-array = "33.0.0"
+arrow-schema = "33.0.0"
 prost-reflect = "0.10.2"
 tempfile = "3.4.0"
-thiserror = "1.0.38"
+thiserror = "1.0.39"
 which = "4.4.0"


### PR DESCRIPTION
Currently Katniss's treatment of enum fields potentially results in inconsistent indices across batches, which may require extra processing down stream (like explicit calls to unify dictionaries). To make it easier for the consumer, we can just parse the enum values from the protobuf schema from the start and give it to the Dictionary field builder.

This PR will entail the following todo list:

- [x] Downgrade arrow-rs to 33 (need to wait for datafusion to catch-up so lance can catch-up).
- [x] Add dict values tracker that will be used by schema/record conversion
- [ ] During parsing of the schema, register dict values
- [ ] During record field builder construction (start of each batch), use the dict values to create the dictionary field builder