### PR TITLE
Use github actions to build + test crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,24 @@
+name: Rust
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install protobuf-compiler
+      run: |
+        sudo apt-get update
+        sudo apt-get install protobuf-compiler
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose


### PR DESCRIPTION
Currently configured to run against pushes and pull-requests for all branches.